### PR TITLE
Makes the actor runnable on the Apify platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 *.log
+
+apify_storage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# First, specify the base Docker image. You can read more about
+# the available images at https://sdk.apify.com/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node-puppeteer-chrome:16
+
+# Second, copy just package.json and package-lock.json since it should be
+# the only file that affects "npm install" in the next step, to speed up the build
+COPY package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+ && npm install --only=prod --no-optional \
+ && echo "Installed NPM packages:" \
+ && (npm list --only=prod --no-optional --all || true) \
+ && echo "Node.js version:" \
+ && node --version \
+ && echo "NPM version:" \
+ && npm --version
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY . ./
+
+# Optionally, specify how to launch the source code of your actor.
+# By default, Apify's base Docker images define the CMD instruction
+# that runs the Node.js source code using the command specified
+# in the "scripts.start" section of the package.json file.
+# In short, the instruction looks something like this:
+#
+# CMD npm start

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
-{ 
+{
   "name": "anti-captcha-recaptcha",
   "version": "1.0.0",
   "description": "Apify act for solving google recaptcha using the anti-captcha.com service",
   "main": "main.js",
+  "scripts": {
+    "start": "node ./main.js"
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
An error: `Could not connect to proxy related to the task, connection refused` is present because of the pre-filled default proxy settings.
I recommend keeping the additional proxy options blank as they weren't present in the latest build and it can cause troubles for the users.